### PR TITLE
icon for the app changed to fit theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/piirustus.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Movies</title>
   </head>

--- a/frontend/public/piirustus.svg
+++ b/frontend/public/piirustus.svg
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="90mm"
+   height="96mm"
+   viewBox="0 0 90 96"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   sodipodi:docname="piirustus.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="166.17009"
+     inkscape:cy="221.67798"
+     inkscape:window-width="1920"
+     inkscape:window-height="1051"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Taso 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#000000;stroke-width:0.231141"
+       id="rect1"
+       width="90"
+       height="69"
+       x="0.086231038"
+       y="27.045403" />
+    <rect
+       style="fill:#f2f2f2;stroke-width:0.029417"
+       id="rect1-8-1-1"
+       width="8.9440374"
+       height="19.574455"
+       x="100.19527"
+       y="37.814213"
+       ry="0"
+       transform="matrix(1,0,-0.69890162,0.71521781,0,0)"
+       inkscape:transform-center-x="0.42677999"
+       inkscape:transform-center-y="0.33672276" />
+    <rect
+       style="fill:#f2f2f2;stroke-width:0.029417"
+       id="rect1-8-1-1-9"
+       width="8.9440374"
+       height="19.574455"
+       x="80.195259"
+       y="37.814213"
+       ry="0"
+       transform="matrix(1,0,-0.69890162,0.71521781,0,0)"
+       inkscape:transform-center-x="0.42677999"
+       inkscape:transform-center-y="0.33672276" />
+    <rect
+       style="fill:#f2f2f2;stroke-width:0.029417"
+       id="rect1-8-1-1-9-1"
+       width="8.9440374"
+       height="19.574455"
+       x="60.195251"
+       y="37.814213"
+       ry="0"
+       transform="matrix(1,0,-0.69890162,0.71521781,0,0)"
+       inkscape:transform-center-x="0.42677999"
+       inkscape:transform-center-y="0.33672276" />
+    <rect
+       style="fill:#f2f2f2;stroke-width:0.029417"
+       id="rect1-8-1-1-9-1-2"
+       width="8.9440374"
+       height="19.574455"
+       x="40.195267"
+       y="37.814213"
+       ry="0"
+       transform="matrix(1,0,-0.69890162,0.71521781,0,0)"
+       inkscape:transform-center-x="0.42677999"
+       inkscape:transform-center-y="0.33672276" />
+    <g
+       id="g5"
+       transform="rotate(-10,-378.76424,396.14406)">
+      <rect
+         style="fill:#000000;stroke-width:0.104115"
+         id="rect1-8"
+         width="90"
+         height="14"
+         x="60"
+         y="87" />
+      <rect
+         style="fill:#f2f2f2;stroke-width:0.0278471"
+         id="rect1-8-1"
+         width="8.9440374"
+         height="17.540939"
+         x="-5.6731415"
+         y="109.00441"
+         ry="0"
+         transform="matrix(1,0,0.60248151,0.79813284,0,0)"
+         inkscape:transform-center-x="-0.15643792"
+         inkscape:transform-center-y="0.33671854" />
+      <rect
+         style="fill:#f2f2f2;stroke-width:0.0278471"
+         id="rect1-8-1-2"
+         width="8.9440374"
+         height="17.540939"
+         x="14.326859"
+         y="109.00441"
+         ry="0"
+         transform="matrix(1,0,0.60248151,0.79813284,0,0)"
+         inkscape:transform-center-x="-0.15643792"
+         inkscape:transform-center-y="0.33671854" />
+      <rect
+         style="fill:#f2f2f2;stroke-width:0.0278471"
+         id="rect1-8-1-2-2"
+         width="8.9440374"
+         height="17.540939"
+         x="34.326859"
+         y="109.00441"
+         ry="0"
+         transform="matrix(1,0,0.60248151,0.79813284,0,0)"
+         inkscape:transform-center-x="-0.15643792"
+         inkscape:transform-center-y="0.33671854" />
+      <rect
+         style="fill:#f2f2f2;stroke-width:0.0278471"
+         id="rect1-8-1-2-2-6"
+         width="8.9440374"
+         height="17.540939"
+         x="54.326859"
+         y="109.00441"
+         ry="0"
+         transform="matrix(1,0,0.60248151,0.79813284,0,0)"
+         inkscape:transform-center-x="-0.15643792"
+         inkscape:transform-center-y="0.33671854" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#000000;stroke-width:0.264583"
+       x="71.096062"
+       y="146.98228"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+         x="71.096062"
+         y="146.98228" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:19.7556px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.264583"
+       x="32.960823"
+       y="65.992439"
+       id="text3"><tspan
+         sodipodi:role="line"
+         id="tspan3"
+         style="font-size:19.7556px;fill:#ffffff;fill-opacity:1;stroke-width:0.264583"
+         x="32.960823"
+         y="65.992439">r15</tspan><tspan
+         sodipodi:role="line"
+         style="font-size:19.7556px;fill:#ffffff;fill-opacity:1;stroke-width:0.264583"
+         x="32.960823"
+         y="90.686935"
+         id="tspan4" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:26.2829px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.352002"
+       x="8.1710911"
+       y="85.167656"
+       id="text5"
+       transform="scale(0.93944771,1.0644552)"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="stroke-width:0.352002"
+         x="8.1710911"
+         y="85.167656">Movies</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
This pull request contains a small change to the favicon used in the `frontend/index.html` file. The favicon reference was updated to use `/piirustus.svg` instead of `/vite.svg`.